### PR TITLE
Cameron.yick/escape periods in vega lite specs instead of deleting

### DIFF
--- a/lux/_version.py
+++ b/lux/_version.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-version_info = (0, 5, 1)
+version_info = (0, 5, 2)
 __version__ = ".".join(map(str, version_info))

--- a/lux/utils/sanitize_column_name.py
+++ b/lux/utils/sanitize_column_name.py
@@ -1,0 +1,14 @@
+import re
+
+# Find the periods that don't have an escape char in front
+# Otherwise, the column name gets replaced repeatedly
+vega_replacement_pattern = r'(?<!\\)\.'
+
+def sanitize_column_name(name):
+    """
+    When vega-lite sees a period ".", it assumes it's looking at a nested object
+    Since lux doesn't process "object"/"dict" columns, this assumption is unhelpful to us
+
+    To treat "." as a regular character and not a call for nested property access, we escape it.
+    """
+    return re.sub(vega_replacement_pattern, "\\.", name)

--- a/lux/utils/sanitize_column_name.py
+++ b/lux/utils/sanitize_column_name.py
@@ -6,9 +6,12 @@ vega_replacement_pattern = r'(?<!\\)\.'
 
 def sanitize_column_name(name):
     """
-    When vega-lite sees a period ".", it assumes it's looking at a nested object
-    Since lux doesn't process "object"/"dict" columns, this assumption is unhelpful to us
+    When vega-lite sees a period ".", it assumes it's looking at data with nested properties.
 
-    To treat "." as a regular character and not a call for nested property access, we escape it.
+    Since lux doesn't process "object"/"dict" columns, this assumption is unhelpful when trying to render the recommended graphs
+
+    To treat "." as a regular character and not a call for nested property access, we escape it with a backslash.
+
+    https://vega.github.io/vega-lite/docs/field.html
     """
     return re.sub(vega_replacement_pattern, "\\.", name)

--- a/lux/vislib/altair/AltairRenderer.py
+++ b/lux/vislib/altair/AltairRenderer.py
@@ -69,12 +69,16 @@ class AltairRenderer:
                     vis.data[attr].iloc[0], pd.Interval
                 ):
                     vis.data[attr] = vis.data[attr].astype(str)
-                if isinstance(attr, str):
-                    if "." in attr:
-                        attr_clause = vis.get_attr_by_attr_name(attr)[0]
-                        # Suppress special character ".", not displayable in Altair
-                        # attr_clause.attribute = attr_clause.attribute.replace(".", "\\.")
-                        vis._vis_data = vis.data.rename(columns={attr: attr.replace(".", "\\.")})
+
+                # No need to rename the attrs at the dataset level
+                # Each vis will add an escape character so that the original field names can be read normally
+                # for full correspondence with the input dataset.
+                # if isinstance(attr, str):
+                #     if "." in attr:
+                #         # attr_clause = vis.get_attr_by_attr_name(attr)[0]
+                #         # Suppress special character ".", not displayable in Altair
+                #         # attr_clause.attribute = attr_clause.attribute.replace(".", "\\.")
+                #         vis._vis_data = vis.data.rename(columns={attr: attr.replace(".", "\\.")})
         if vis.mark == "histogram":
             chart = Histogram(vis)
         elif vis.mark == "bar":

--- a/lux/vislib/altair/AltairRenderer.py
+++ b/lux/vislib/altair/AltairRenderer.py
@@ -73,8 +73,8 @@ class AltairRenderer:
                     if "." in attr:
                         attr_clause = vis.get_attr_by_attr_name(attr)[0]
                         # Suppress special character ".", not displayable in Altair
-                        # attr_clause.attribute = attr_clause.attribute.replace(".", "")
-                        vis._vis_data = vis.data.rename(columns={attr: attr.replace(".", "")})
+                        # attr_clause.attribute = attr_clause.attribute.replace(".", "\\.")
+                        vis._vis_data = vis.data.rename(columns={attr: attr.replace(".", "\\.")})
         if vis.mark == "histogram":
             chart = Histogram(vis)
         elif vis.mark == "bar":

--- a/lux/vislib/altair/BarChart.py
+++ b/lux/vislib/altair/BarChart.py
@@ -13,9 +13,11 @@
 #  limitations under the License.
 
 from lux.vislib.altair.AltairChart import AltairChart
+from lux.utils.sanitize_column_name import sanitize_column_name
 import altair as alt
 import lux
 import math
+
 
 alt.data_transformers.disable_max_rows()
 from lux.utils.utils import get_agg_title
@@ -54,9 +56,9 @@ class BarChart(AltairChart):
             y_attr_abv = y_attr.attribute[:prefix_len] + "..." + y_attr.attribute[-suffix_len:]
 
         if isinstance(x_attr.attribute, str):
-            x_attr.attribute = x_attr.attribute.replace(".", "\\.")
+            x_attr.attribute = sanitize_column_name(x_attr.attribute)
         if isinstance(y_attr.attribute, str):
-            y_attr.attribute = y_attr.attribute.replace(".", "\\.")
+            y_attr.attribute = sanitize_column_name(y_attr.attribute)
 
         # To get datetime to display correctly on bar charts
         if x_attr.data_type == "temporal":

--- a/lux/vislib/altair/BarChart.py
+++ b/lux/vislib/altair/BarChart.py
@@ -54,9 +54,9 @@ class BarChart(AltairChart):
             y_attr_abv = y_attr.attribute[:prefix_len] + "..." + y_attr.attribute[-suffix_len:]
 
         if isinstance(x_attr.attribute, str):
-            x_attr.attribute = x_attr.attribute.replace(".", "")
+            x_attr.attribute = x_attr.attribute.replace(".", "\\.")
         if isinstance(y_attr.attribute, str):
-            y_attr.attribute = y_attr.attribute.replace(".", "")
+            y_attr.attribute = y_attr.attribute.replace(".", "\\.")
 
         # To get datetime to display correctly on bar charts
         if x_attr.data_type == "temporal":
@@ -125,7 +125,7 @@ class BarChart(AltairChart):
             )
 
             self._topkcode = f"""text = alt.Chart(visData).mark_text(
-			x={155 * plotting_scale}, 
+			x={155 * plotting_scale},
 			y={142 * plotting_scale},
 			align="right",
 			color = "#ff8e04",

--- a/lux/vislib/altair/Choropleth.py
+++ b/lux/vislib/altair/Choropleth.py
@@ -60,9 +60,9 @@ class Choropleth(AltairChart):
             y_attr_abv = y_attr.attribute[:15] + "..." + y_attr.attribute[-10:]
 
         if isinstance(x_attr.attribute, str):
-            x_attr.attribute = x_attr.attribute.replace(".", "")
+            x_attr.attribute = x_attr.attribute.replace(".", "\\.")
         if isinstance(y_attr.attribute, str):
-            y_attr.attribute = y_attr.attribute.replace(".", "")
+            y_attr.attribute = y_attr.attribute.replace(".", "\\.")
 
         self.data = AltairChart.sanitize_dataframe(self.data)
 

--- a/lux/vislib/altair/Choropleth.py
+++ b/lux/vislib/altair/Choropleth.py
@@ -18,6 +18,7 @@ import pandas as pd
 from iso3166 import countries
 
 alt.data_transformers.disable_max_rows()
+from lux.utils.sanitize_column_name import sanitize_column_name
 
 
 class Choropleth(AltairChart):
@@ -60,9 +61,9 @@ class Choropleth(AltairChart):
             y_attr_abv = y_attr.attribute[:15] + "..." + y_attr.attribute[-10:]
 
         if isinstance(x_attr.attribute, str):
-            x_attr.attribute = x_attr.attribute.replace(".", "\\.")
+            x_attr.attribute = sanitize_column_name(x_attr.attribute)
         if isinstance(y_attr.attribute, str):
-            y_attr.attribute = y_attr.attribute.replace(".", "\\.")
+            y_attr.attribute = sanitize_column_name(y_attr.attribute)
 
         self.data = AltairChart.sanitize_dataframe(self.data)
 

--- a/lux/vislib/altair/Heatmap.py
+++ b/lux/vislib/altair/Heatmap.py
@@ -48,9 +48,9 @@ class Heatmap(AltairChart):
             y_attr_abv = y_attr.attribute[:15] + "..." + y_attr.attribute[-10:]
 
         if isinstance(x_attr.attribute, str):
-            x_attr.attribute = x_attr.attribute.replace(".", "")
+            x_attr.attribute = x_attr.attribute.replace(".", "\\.")
         if isinstance(y_attr.attribute, str):
-            y_attr.attribute = y_attr.attribute.replace(".", "")
+            y_attr.attribute = y_attr.attribute.replace(".", "\\.")
 
         chart = (
             alt.Chart(self.data)

--- a/lux/vislib/altair/Heatmap.py
+++ b/lux/vislib/altair/Heatmap.py
@@ -14,6 +14,7 @@
 
 from lux.vislib.altair.AltairChart import AltairChart
 import altair as alt
+from lux.utils.sanitize_column_name import sanitize_column_name
 
 alt.data_transformers.disable_max_rows()
 
@@ -48,9 +49,9 @@ class Heatmap(AltairChart):
             y_attr_abv = y_attr.attribute[:15] + "..." + y_attr.attribute[-10:]
 
         if isinstance(x_attr.attribute, str):
-            x_attr.attribute = x_attr.attribute.replace(".", "\\.")
+            x_attr.attribute = sanitize_column_name(x_attr.attribute)
         if isinstance(y_attr.attribute, str):
-            y_attr.attribute = y_attr.attribute.replace(".", "\\.")
+            y_attr.attribute = sanitize_column_name(y_attr.attribute)
 
         chart = (
             alt.Chart(self.data)

--- a/lux/vislib/altair/Histogram.py
+++ b/lux/vislib/altair/Histogram.py
@@ -17,6 +17,7 @@ import altair as alt
 import math
 
 alt.data_transformers.disable_max_rows()
+from lux.utils.sanitize_column_name import sanitize_column_name
 
 
 class Histogram(AltairChart):
@@ -48,7 +49,7 @@ class Histogram(AltairChart):
         x_range = abs(x_max - x_min)
 
         if isinstance(msr_attr.attribute, str):
-            msr_attr.attribute = msr_attr.attribute.replace(".", "\\.")
+            msr_attr.attribute = sanitize_column_name(msr_attr.attribute)
         markbar = compute_bin_width(self.data[msr_attr.attribute])
         step = abs(self.data[msr_attr.attribute][1] - self.data[msr_attr.attribute][0])
 

--- a/lux/vislib/altair/Histogram.py
+++ b/lux/vislib/altair/Histogram.py
@@ -48,7 +48,7 @@ class Histogram(AltairChart):
         x_range = abs(x_max - x_min)
 
         if isinstance(msr_attr.attribute, str):
-            msr_attr.attribute = msr_attr.attribute.replace(".", "")
+            msr_attr.attribute = msr_attr.attribute.replace(".", "\\.")
         markbar = compute_bin_width(self.data[msr_attr.attribute])
         step = abs(self.data[msr_attr.attribute][1] - self.data[msr_attr.attribute][0])
 

--- a/lux/vislib/altair/LineChart.py
+++ b/lux/vislib/altair/LineChart.py
@@ -13,10 +13,12 @@
 #  limitations under the License.
 
 from lux.vislib.altair.AltairChart import AltairChart
+
 import altair as alt
 
 alt.data_transformers.disable_max_rows()
 from lux.utils.utils import get_agg_title
+from lux.utils.sanitize_column_name import sanitize_column_name
 
 
 class LineChart(AltairChart):
@@ -54,9 +56,9 @@ class LineChart(AltairChart):
             y_attr_abv = y_attr.attribute[:15] + "..." + y_attr.attribute[-10:]
 
         if isinstance(x_attr.attribute, str):
-            x_attr.attribute = x_attr.attribute.replace(".", "\\.")
+            x_attr.attribute = sanitize_column_name(x_attr.attribute)
         if isinstance(y_attr.attribute, str):
-            y_attr.attribute = y_attr.attribute.replace(".", "\\.")
+            y_attr.attribute = sanitize_column_name(y_attr.attribute)
 
         # Remove NaNs only for Line Charts (offsets axis range)
         self.data = self.data.dropna(subset=[x_attr.attribute, y_attr.attribute])

--- a/lux/vislib/altair/LineChart.py
+++ b/lux/vislib/altair/LineChart.py
@@ -54,9 +54,9 @@ class LineChart(AltairChart):
             y_attr_abv = y_attr.attribute[:15] + "..." + y_attr.attribute[-10:]
 
         if isinstance(x_attr.attribute, str):
-            x_attr.attribute = x_attr.attribute.replace(".", "")
+            x_attr.attribute = x_attr.attribute.replace(".", "\\.")
         if isinstance(y_attr.attribute, str):
-            y_attr.attribute = y_attr.attribute.replace(".", "")
+            y_attr.attribute = y_attr.attribute.replace(".", "\\.")
 
         # Remove NaNs only for Line Charts (offsets axis range)
         self.data = self.data.dropna(subset=[x_attr.attribute, y_attr.attribute])

--- a/lux/vislib/altair/ScatterChart.py
+++ b/lux/vislib/altair/ScatterChart.py
@@ -53,9 +53,9 @@ class ScatterChart(AltairChart):
         y_max = self.vis.min_max[y_attr.attribute][1]
 
         if isinstance(x_attr.attribute, str):
-            x_attr.attribute = x_attr.attribute.replace(".", "")
+            x_attr.attribute = x_attr.attribute.replace(".", "\\.")
         if isinstance(y_attr.attribute, str):
-            y_attr.attribute = y_attr.attribute.replace(".", "")
+            y_attr.attribute = y_attr.attribute.replace(".", "\\.")
         self.data = AltairChart.sanitize_dataframe(self.data)
         chart = (
             alt.Chart(self.data)

--- a/lux/vislib/altair/ScatterChart.py
+++ b/lux/vislib/altair/ScatterChart.py
@@ -16,7 +16,7 @@ from lux.vislib.altair.AltairChart import AltairChart
 import altair as alt
 
 alt.data_transformers.disable_max_rows()
-
+from lux.utils.sanitize_column_name import sanitize_column_name
 
 class ScatterChart(AltairChart):
     """
@@ -53,9 +53,9 @@ class ScatterChart(AltairChart):
         y_max = self.vis.min_max[y_attr.attribute][1]
 
         if isinstance(x_attr.attribute, str):
-            x_attr.attribute = x_attr.attribute.replace(".", "\\.")
+            x_attr.attribute = sanitize_column_name(x_attr.attribute)
         if isinstance(y_attr.attribute, str):
-            y_attr.attribute = y_attr.attribute.replace(".", "\\.")
+            y_attr.attribute = sanitize_column_name(y_attr.attribute)
         self.data = AltairChart.sanitize_dataframe(self.data)
         chart = (
             alt.Chart(self.data)


### PR DESCRIPTION
## Overview

- Change handling of columns with `.` inside. Aim to escape them instead.


## Changes

- TKTK


## Example Output

Describe the expected behavior of your changes. If applicable, please include a screenshot.
